### PR TITLE
Add redirect domain base

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -28,11 +28,12 @@ type Authenticator struct {
 
 // Config for authenticator handler.
 type Config struct {
-	Bearer      *bearer.Config
-	Oauth       map[string]*ServiceOauth
-	TLSEnabled  bool
-	Host        string
-	RedirectURL string
+	Bearer        *bearer.Config
+	Oauth         map[string]*ServiceOauth
+	TLSEnabled    bool
+	Host          string
+	RedirectURL   string
+	RedirectOauth string
 }
 
 // New creates authenticator using config.

--- a/cmd/neofs-send-authz/app.go
+++ b/cmd/neofs-send-authz/app.go
@@ -147,17 +147,22 @@ func (a *app) initAuthCfg(key *keys.PrivateKey) {
 			ContainerID: containerID,
 			LifeTime:    a.cfg.GetUint64(cfgBearerLifetime),
 		},
-		Oauth:       make(map[string]*auth.ServiceOauth),
-		TLSEnabled:  a.cfg.GetString(cfgTLSCertificate) != "" || a.cfg.GetString(cfgTLSKey) != "",
-		Host:        a.cfg.GetString(cfgListenAddress),
-		RedirectURL: a.cfg.GetString(cfgRedirectURL),
+		Oauth:         make(map[string]*auth.ServiceOauth),
+		TLSEnabled:    a.cfg.GetString(cfgTLSCertificate) != "" || a.cfg.GetString(cfgTLSKey) != "",
+		Host:          a.cfg.GetString(cfgListenAddress),
+		RedirectURL:   a.cfg.GetString(cfgRedirectURL),
+		RedirectOauth: a.cfg.GetString(cfgRedirectOauth),
 	}
 
 	scheme := "http"
 	if a.authCfg.TLSEnabled {
 		scheme += "s"
 	}
-	redirectURL := fmt.Sprintf(callbackURLFmt, scheme, a.authCfg.Host)
+	base := a.authCfg.Host
+	if len(a.authCfg.RedirectOauth) != 0 {
+		base = a.authCfg.RedirectOauth
+	}
+	redirectURL := fmt.Sprintf(callbackURLFmt, scheme, base)
 
 	for key := range a.cfg.GetStringMap(cfgOauth) {
 		oauth := &oauth2.Config{

--- a/cmd/neofs-send-authz/config.go
+++ b/cmd/neofs-send-authz/config.go
@@ -57,6 +57,7 @@ const (
 	cfgOauthEndpointAuthFmt  = "oauth.%s.endpoint.auth"
 	cfgOauthEndpointTokenFmt = "oauth.%s.endpoint.token"
 	cfgRedirectURL           = "redirect.url"
+	cfgRedirectOauth         = "redirect.oauth"
 	callbackURLFmt           = "%s://%s/callback"
 )
 

--- a/config.yaml
+++ b/config.yaml
@@ -17,4 +17,8 @@ oauth:
       token: "https://github.com/login/oauth/access_token"
 
 redirect:
+  # This URL base is used to prepare callback URL for authentication server.
+  # If omitted, then listen address is used. Should not contain scheme.
+  oauth: "my.website.com:8080"
+  # Redirect to this URL **after** successful authentication
   url: "/"


### PR DESCRIPTION
The app might be used with `--listen_address 0.0.0.0:8080`
but redirect URL should contain proper domain. In this case
define `redirect.base` config parameter. It will override
listen address in redirect URL with specified `domain:port`.

Signed-off-by: Alex Vanin <alexey@nspcc.ru>