### PR TITLE
Fix false fatal err while reading peers in config

### DIFF
--- a/cmd/neofs-send-authz/app.go
+++ b/cmd/neofs-send-authz/app.go
@@ -111,7 +111,11 @@ func (a *app) initPool(ctx context.Context, key *keys.PrivateKey) {
 	p.SetClientRebalanceInterval(rebalanceInterval)
 
 	for i := 0; ; i++ {
-		key := cfgPeers + "." + strconv.Itoa(i) + "."
+		key := cfgPeers + "." + strconv.Itoa(i)
+		if !a.cfg.IsSet(key) {
+			break
+		}
+		key += "."
 		address := a.cfg.GetString(key + "address")
 		weight := a.cfg.GetFloat64(key + "weight")
 		priority := a.cfg.GetInt(key + "priority")


### PR DESCRIPTION
Earlier we didn't differ is variable  empty or just not set, that's why when we met empty address we just finished reading of the list of peers and printed "skip, empty address" anyway:
```
if address == "" {
	a.log.Warn("skip, empty address")
	break
}
```

Changes in the last commit added check if `peers.i.address` is empty and if true, raise fatal. It led to false error when the  list of peers is over. 