### PR TITLE
Make bearer cookie name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ rebalance_timer: 15s
 ```
 | Parameter         | Type       | Default value | Description                                                                                        |
 |-------------------|------------|---------------|----------------------------------------------------------------------------------------------------|
+| `bearer_cookie_name`| `string` | `Bearer`      | The name of the cookie holding bearer token.                                                       |
 | `redirect.url`    | `string`   |               | URL to redirect users going through the OAuth flow                                                 |
 | `listen_address`  | `string`   |               | The address that the app is listening on.                                                          |
 | `logger.level`    | `string`   | `debug`       | Logging level.<br/>Possible values:  `debug`, `info`, `warn`, `error`, `dpanic`, `panic`, `fatal`. |

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -104,8 +104,6 @@ func (u *Authenticator) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Authorization", "Bearer "+strToken)
-
 	http.SetCookie(w, &http.Cookie{
 		Name:   "Bearer",
 		Value:  strToken,

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -27,11 +27,12 @@ type Authenticator struct {
 
 // Config for authenticator handler.
 type Config struct {
-	Bearer      *bearer.Config
-	Oauth       map[string]*ServiceOauth
-	TLSEnabled  bool
-	Host        string
-	RedirectURL string
+	Bearer           *bearer.Config
+	BearerCookieName string
+	Oauth            map[string]*ServiceOauth
+	TLSEnabled       bool
+	Host             string
+	RedirectURL      string
 }
 
 // New creates authenticator using config.
@@ -105,7 +106,7 @@ func (u *Authenticator) Callback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:   "Bearer",
+		Name:   u.config.BearerCookieName,
 		Value:  strToken,
 		MaxAge: 600,
 	})

--- a/cmd/neofs-oauthz/app.go
+++ b/cmd/neofs-oauthz/app.go
@@ -208,6 +208,10 @@ func (a *app) initAuthCfg(key *keys.PrivateKey) {
 	if len(listenAddress) == 0 {
 		listenAddress = defaultListenAddress
 	}
+	bearerCookieName := a.cfg.GetString(cfgBearerCookieName)
+	if len(bearerCookieName) == 0 {
+		bearerCookieName = defaultBearerCookieName
+	}
 
 	a.authCfg = &auth.Config{
 		Bearer: &bearer.Config{
@@ -216,10 +220,11 @@ func (a *app) initAuthCfg(key *keys.PrivateKey) {
 			ContainerID: containerID,
 			LifeTime:    lifetime,
 		},
-		Oauth:       make(map[string]*auth.ServiceOauth),
-		TLSEnabled:  a.cfg.GetString(cfgTLSCertificate) != "" || a.cfg.GetString(cfgTLSKey) != "",
-		Host:        listenAddress,
-		RedirectURL: a.cfg.GetString(cfgRedirectURL),
+		BearerCookieName: bearerCookieName,
+		Oauth:            make(map[string]*auth.ServiceOauth),
+		TLSEnabled:       a.cfg.GetString(cfgTLSCertificate) != "" || a.cfg.GetString(cfgTLSKey) != "",
+		Host:             listenAddress,
+		RedirectURL:      a.cfg.GetString(cfgRedirectURL),
 	}
 
 	redirectURLCallback := fmt.Sprintf(callbackURLFmt, a.authCfg.RedirectURL)

--- a/cmd/neofs-oauthz/config.go
+++ b/cmd/neofs-oauthz/config.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	defaultRebalanceTimer = 15 * time.Second
-	defaultRequestTimeout = 15 * time.Second
-	defaultConnectTimeout = 30 * time.Second
-	defaultBearerLifetime = 30
+	defaultBearerCookieName = "Bearer"
+	defaultBearerLifetime   = 30
+	defaultConnectTimeout   = 30 * time.Second
+	defaultRebalanceTimer   = 15 * time.Second
+	defaultRequestTimeout   = 15 * time.Second
 
 	defaultListenAddress = "0.0.0.0:8083"
 
@@ -43,9 +44,8 @@ const (
 	cmdHelp    = "help"
 	cmdVersion = "version"
 	cmdConfig  = "config"
-)
 
-const (
+	cfgBearerCookieName      = "bearer_cookie_name"
 	cfgOauth                 = "oauth"
 	cfgOauthIDFmt            = "oauth.%s.id"
 	cfgOauthSecretFmt        = "oauth.%s.secret"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,6 +38,8 @@ listen_address: 0.0.0.0:8083
 logger:
   level: debug
 
+bearer_cookie_name: "Bearer"
+
 connect_timeout: 30s
 request_timeout: 15s
 rebalance_timer: 15s


### PR DESCRIPTION
With proper configuration this fixes our send.fs.neo.org problem when we have two containers involved in serving various parts of the website.