### PR TITLE
cmd: handle http.ErrServerClosed properly, fix #17

### DIFF
--- a/cmd/neofs-oauthz/app.go
+++ b/cmd/neofs-oauthz/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -275,7 +276,7 @@ func (a *app) Serve(ctx context.Context) {
 		a.log.Info("running web server", zap.String("address", a.webServer.Addr))
 		err = a.webServer.ListenAndServe()
 	}
-	if err != nil {
+	if !errors.Is(err, http.ErrServerClosed) {
 		a.log.Fatal("could not start server", zap.Error(err))
 	}
 }


### PR DESCRIPTION
ListenAndServe _always_ returns an error, http.ErrServerClosed means it's stopped normally, no need to panic in this case.