### PR TITLE
bearer: set user ID only if it's configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ neofs:
     address:  NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP # Account address. If omitted default one will be used.
     passphrase: '' # Passphrase to decrypt wallet. If you're using a wallet without a password, place '' here.
   cid: 2qAEwyRwV1sMmq8pc32mKCt1SRmTBXrzP9KbfMoHmqYM
-  owner_id: NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP
+  bearer_user_id: NUVPACMnKFhpuHjsRjhUvXz1XhqfGZYVtY
 ```
 | Parameter                 | Type     | Default value | Description                                                              |
 |---------------------------|----------|---------------|--------------------------------------------------------------------------|
@@ -71,7 +71,7 @@ neofs:
 | `neofs.wallet.address`    | `string` |               | Account address to get from wallet. If omitted default one will be used. |
 | `neofs.wallet.passphrase` | `string` |               | Passphrase to decrypt wallet.                                            |
 | `neofs.cid`               | `string` |               | container ID in NeoFS where objects will be stored                       |
-| `neofs.owner_id`          | `string` |               | user ID which will be used to manage objects in a NeoFS container        |
+| `neofs.bearer_user_id`    | `string` |               | User ID that will be given the right to upload objects into NeoFS container (can be omitted to allow this for any owner of the token) |
 
 ### NeoFS nodes section
 ```

--- a/bearer/bearer.go
+++ b/bearer/bearer.go
@@ -26,7 +26,7 @@ func NewGenerator(config *Config) *Generator {
 // Config for bearer token generator.
 type Config struct {
 	Key         *keys.PrivateKey
-	OwnerID     user.ID
+	UserID      *user.ID
 	ContainerID cid.ID
 	LifeTime    uint64
 }
@@ -47,7 +47,9 @@ func (b *Generator) NewBearer(email string, currentEpoch uint64) (string, string
 
 	var bt bearer.Token
 	bt.SetEACLTable(*t)
-	bt.ForUser(b.config.OwnerID)
+	if b.config.UserID != nil {
+		bt.ForUser(*b.config.UserID)
+	}
 	bt.SetExp(currentEpoch + b.config.LifeTime)
 
 	if err := bt.Sign(neofsecdsa.Signer(b.config.Key.PrivateKey)); err != nil {

--- a/cmd/neofs-oauthz/app.go
+++ b/cmd/neofs-oauthz/app.go
@@ -195,9 +195,15 @@ func (a *app) initAuthCfg(key *keys.PrivateKey) {
 		a.log.Fatal("container id is empty or malformed", zap.Error(err))
 	}
 
-	var ownerID user.ID
-	if err := ownerID.DecodeString(a.cfg.GetString(cfgOwnerID)); err != nil {
-		a.log.Fatal("user id is empty or malformed", zap.Error(err))
+	var (
+		cfgUser = a.cfg.GetString(cfgUserID)
+		userID  *user.ID
+	)
+	if cfgUser != "" {
+		userID = new(user.ID)
+		if err := userID.DecodeString(cfgUser); err != nil {
+			a.log.Fatal("user id is malformed", zap.Error(err))
+		}
 	}
 
 	lifetime := a.cfg.GetUint64(cfgBearerLifetime)
@@ -217,7 +223,7 @@ func (a *app) initAuthCfg(key *keys.PrivateKey) {
 	a.authCfg = &auth.Config{
 		Bearer: &bearer.Config{
 			Key:         key,
-			OwnerID:     ownerID,
+			UserID:      userID,
 			ContainerID: containerID,
 			LifeTime:    lifetime,
 		},

--- a/cmd/neofs-oauthz/config.go
+++ b/cmd/neofs-oauthz/config.go
@@ -28,7 +28,7 @@ const (
 	cfgTLSKey         = "tls_key"
 
 	cfgContainerID           = "neofs.cid"
-	cfgOwnerID               = "neofs.owner_id"
+	cfgUserID                = "neofs.bearer_user_id"
 	cfgBearerLifetime        = "neofs.bearer_lifetime"
 	cfgNeoFSWalletPath       = "neofs.wallet.path"
 	cfgNeoFSWalletPassphrase = "neofs.wallet.passphrase"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,12 +17,12 @@ oauth:
       token: "https://github.com/login/oauth/access_token"
 
 neofs:
+  bearer_user_id: NUVPACMnKFhpuHjsRjhUvXz1XhqfGZYVtY # If set, limits bearer token issued to the specified user ID.
   wallet:
     path: /path/to/wallet.json
     passphrase: '' # Passphrase to decrypt wallet. If you're using a wallet without a password, place '' here.
     address:  NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP # Account address. If omitted default one will be used.
   cid: 2qAEwyRwV1sMmq8pc32mKCt1SRmTBXrzP9KbfMoHmqYM
-  owner_id: NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP
 
 peers:
   0:


### PR DESCRIPTION
And have a better name for it.

Gateways may have arbitrary keys and we have some number of them, so there is a need to issue a token that works for any uploader key. The possibility to have key-bound token is still there as an option.