### PR TITLE
bearer: allow to override email attribute name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ neofs:
     passphrase: '' # Passphrase to decrypt wallet. If you're using a wallet without a password, place '' here.
   cid: 2qAEwyRwV1sMmq8pc32mKCt1SRmTBXrzP9KbfMoHmqYM
   bearer_user_id: NUVPACMnKFhpuHjsRjhUvXz1XhqfGZYVtY
+  bearer_email_attribute: email
 ```
 | Parameter                 | Type     | Default value | Description                                                              |
 |---------------------------|----------|---------------|--------------------------------------------------------------------------|
@@ -72,6 +73,7 @@ neofs:
 | `neofs.wallet.passphrase` | `string` |               | Passphrase to decrypt wallet.                                            |
 | `neofs.cid`               | `string` |               | container ID in NeoFS where objects will be stored                       |
 | `neofs.bearer_user_id`    | `string` |               | User ID that will be given the right to upload objects into NeoFS container (can be omitted to allow this for any owner of the token) |
+| `neofs.bearer_email_attribute`| `string`| `Email`    | The name of the NeoFS attribute used as to match user by his e-mail address (case sensitive as all NeoFS attributes) |
 
 ### NeoFS nodes section
 ```

--- a/bearer/bearer.go
+++ b/bearer/bearer.go
@@ -25,6 +25,7 @@ func NewGenerator(config *Config) *Generator {
 
 // Config for bearer token generator.
 type Config struct {
+	EmailAttr   string
 	Key         *keys.PrivateKey
 	UserID      *user.ID
 	ContainerID cid.ID
@@ -38,7 +39,7 @@ func (b *Generator) NewBearer(email string, currentEpoch uint64) (string, string
 	t := eacl.CreateTable(b.config.ContainerID)
 	// order of rec is important
 	rec := eacl.CreateRecord(eacl.ActionAllow, eacl.OperationPut)
-	rec.AddObjectAttributeFilter(eacl.MatchStringEqual, "Email", hashedEmail)
+	rec.AddObjectAttributeFilter(eacl.MatchStringEqual, b.config.EmailAttr, hashedEmail)
 	eacl.AddFormedTarget(rec, eacl.RoleOthers)
 	t.AddRecord(rec)
 	rec2 := eacl.CreateRecord(eacl.ActionDeny, eacl.OperationPut)

--- a/cmd/neofs-oauthz/app.go
+++ b/cmd/neofs-oauthz/app.go
@@ -206,6 +206,10 @@ func (a *app) initAuthCfg(key *keys.PrivateKey) {
 		}
 	}
 
+	emailattr := a.cfg.GetString(cfgEmailAttr)
+	if len(emailattr) == 0 {
+		emailattr = defaultEmailAttr
+	}
 	lifetime := a.cfg.GetUint64(cfgBearerLifetime)
 	if lifetime == 0 {
 		lifetime = defaultBearerLifetime
@@ -222,6 +226,7 @@ func (a *app) initAuthCfg(key *keys.PrivateKey) {
 
 	a.authCfg = &auth.Config{
 		Bearer: &bearer.Config{
+			EmailAttr:   emailattr,
 			Key:         key,
 			UserID:      userID,
 			ContainerID: containerID,

--- a/cmd/neofs-oauthz/config.go
+++ b/cmd/neofs-oauthz/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	defaultEmailAttr        = "Email"
 	defaultBearerCookieName = "Bearer"
 	defaultBearerLifetime   = 30
 	defaultConnectTimeout   = 30 * time.Second
@@ -28,6 +29,7 @@ const (
 	cfgTLSKey         = "tls_key"
 
 	cfgContainerID           = "neofs.cid"
+	cfgEmailAttr             = "neofs.bearer_email_attribute"
 	cfgUserID                = "neofs.bearer_user_id"
 	cfgBearerLifetime        = "neofs.bearer_lifetime"
 	cfgNeoFSWalletPath       = "neofs.wallet.path"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,7 @@ oauth:
       token: "https://github.com/login/oauth/access_token"
 
 neofs:
+  bearer_email_attribute: email # Exact name of the NeoFS attribute to be used for e-mail hash matching.
   bearer_user_id: NUVPACMnKFhpuHjsRjhUvXz1XhqfGZYVtY # If set, limits bearer token issued to the specified user ID.
   wallet:
     path: /path/to/wallet.json


### PR DESCRIPTION
It can be Email, can be email, can be e-mail, whatever you want, but it better be configurable since NeoFS is case-sensitive and some variants are more appropriate in some cases.