### PR TITLE
workflows: replace macos-12 with macos-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{matrix.os.name}}
     strategy:
       matrix:
-        os: [{ name: ubuntu-20.04, bin-name: linux }] # { name: windows-2022, bin-name: windows }, { name: macos-12, bin-name: darwin }
+        os: [{ name: ubuntu-20.04, bin-name: linux }] # { name: windows-2022, bin-name: windows }, { name: macos-14, bin-name: darwin }
         arch: [amd64] # arm64
 
     steps:


### PR DESCRIPTION
macos-12 runner is going to die soon.

https://github.com/actions/runner-images/issues/10721