### PR TITLE
cmd: disable zap log sampling

### DIFF
--- a/cmd/neofs-oauthz/config.go
+++ b/cmd/neofs-oauthz/config.go
@@ -146,6 +146,7 @@ func newLogger(v *viper.Viper) (*zap.Logger, error) {
 		}
 	}
 
+	c.Sampling = nil
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		c.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	} else {


### PR DESCRIPTION
Skipping log lines is not safe to be used by default. Notice that s3-authmate doesn't have this problem because of the way it constructs its settings.

See also:
 * https://github.com/nspcc-dev/neofs-node/pull/3011
 * https://github.com/nspcc-dev/neo-go/pull/598