### PR TITLE
github: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: mv ./bin/neofs-oauthz* ./bin/neofs-oauthz-${{ matrix.os.bin-name }}-${{ matrix.arch }}${{ (matrix.os.bin-name == 'windows' && '.exe') || '' }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: neofs-oauthz-${{ matrix.os.bin-name }}-${{ matrix.arch }}
           path: ./bin/neofs-oauthz*


### PR DESCRIPTION
v3 is no longer supported and builds just fail with it.